### PR TITLE
feat: add env variables to control starting values of readiness/liveness/debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For more information: https://raw.githubusercontent.com/kubernetes/website/main/
               fieldPath: metadata.name
 ```
 
-You can additionally choose the starting values of the liveness- and readiness probes by setting the `KUBELEARN_ALIVE` and `KUBELEARN_READY` env variables.
+You can additionally choose the starting values of the liveness- and readiness probes, as well as the debug mode, by setting the `KUBELEARN_ALIVE`, `KUBELEARN_READY` and `KUBELEARN_DEBUG` env variables.
 
 # Example output from /
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ For more information: https://raw.githubusercontent.com/kubernetes/website/main/
               fieldPath: metadata.name
 ```
 
+You can additionally choose the starting values of the liveness- and readiness probes by setting the `KUBELEARN_ALIVE` and `KUBELEARN_READY` env variables.
+
 # Example output from /
 ```
 curl http://localhost:8080/

--- a/main.go
+++ b/main.go
@@ -135,6 +135,17 @@ func getEnv(key, fallback string) string {
 	return fallback
 }
 
+// Gets the env variable as a boolean.
+// Handles "1", "t", "T", "TRUE", "true", "True" as truthy, everything else (including env variable being empty) as falsy
+// If the env variable isn't set at all, uses the given fallback
+func getEnvBool(key string, fallback bool) bool {
+	if value, ok := os.LookupEnv(key); ok {
+		parsed, err := strconv.ParseBool(value)
+		return parsed && err == nil
+	}
+	return fallback
+}
+
 var prompt *log.Entry
 var pod_name string
 var node_name string
@@ -150,8 +161,8 @@ func main() {
 	})
 
 	// initialize probes
-	probes.liveness = true
-	probes.readiness = true
+	probes.liveness = getEnvBool("KUBELEARN_ALIVE", true)
+	probes.readiness = getEnvBool("KUBELEARN_READY", true)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		now := time.Now().Format("01-02-2006 15:04:05")

--- a/main.go
+++ b/main.go
@@ -163,6 +163,12 @@ func main() {
 	// initialize probes
 	probes.liveness = getEnvBool("KUBELEARN_ALIVE", true)
 	probes.readiness = getEnvBool("KUBELEARN_READY", true)
+	if getEnvBool("KUBELEARN_DEBUG", false) {
+		cmd_verbose(cmd{
+			cmd_name:  "verbose",
+			cmd_value: true,
+		})
+	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		now := time.Now().Format("01-02-2006 15:04:05")


### PR DESCRIPTION
Adds the env variables `KUBELEARN_ALIVE`, `KUBELEARN_READY` and `KUBELEARN_DEBUG`, which handle the initial state of the liveness/readiness probes and debug mode.

Useful for situations where you want to change them without a TTY, or where you need them set before you can manually update them.